### PR TITLE
Add CLI for organizing starred repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # GitHub-Star-Organiser
-Automatically scans your starred repos and lists, analyses each repo and organises them into lists for you.
+
+A simple CLI tool that connects to your GitHub account, analyses the README of each starred repository with the OpenAI API and organises them into lists.
+
+## Usage
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Run the organiser:
+
+```bash
+python organize_stars.py --create-new
+```
+
+Provide your GitHub OAuth app client ID with `--client-id` (or via `GITHUB_CLIENT_ID`) to log in using the browser-based device flow. Without a client ID a personal access token will be requested instead. You will also be prompted for an OpenAI API key. Lists are stored in `lists.json` and `--create-new` allows new categories to be created automatically.
+

--- a/organize_stars.py
+++ b/organize_stars.py
@@ -1,0 +1,110 @@
+import json
+import os
+import time
+from getpass import getpass
+
+import click
+from github import Github
+import openai
+import requests
+
+
+def device_login(client_id):
+    """Perform GitHub device flow login and return an access token."""
+    resp = requests.post(
+        "https://github.com/login/device/code",
+        data={"client_id": client_id, "scope": "repo read:user"},
+        headers={"Accept": "application/json"},
+    )
+    data = resp.json()
+    click.echo(f"Open {data['verification_uri']} and enter code {data['user_code']}")
+    while True:
+        time.sleep(data.get("interval", 5))
+        poll = requests.post(
+            "https://github.com/login/oauth/access_token",
+            data={
+                "client_id": client_id,
+                "device_code": data["device_code"],
+                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+            },
+            headers={"Accept": "application/json"},
+        )
+        result = poll.json()
+        if "access_token" in result:
+            return result["access_token"]
+        if result.get("error") != "authorization_pending":
+            raise RuntimeError(result.get("error_description", "Login failed"))
+
+
+@click.command()
+@click.option('--token', help='GitHub personal access token', default=lambda: os.environ.get('GITHUB_TOKEN'))
+@click.option('--client-id', help='GitHub OAuth app client ID', default=lambda: os.environ.get('GITHUB_CLIENT_ID'))
+@click.option('--list-file', default='lists.json', show_default=True, help='Path to JSON file with category lists')
+@click.option('--create-new', is_flag=True, help='Allow creating new lists if the model suggests a new category')
+def main(token, client_id, list_file, create_new):
+    """Organise starred repositories into lists using OpenAI."""
+    if not token:
+        if client_id:
+            try:
+                token = device_login(client_id)
+            except Exception as exc:
+                click.echo(f'Device login failed: {exc}')
+        if not token:
+            token = getpass('GitHub token: ')
+    gh = Github(token)
+    try:
+        user = gh.get_user()
+        stars = list(user.get_starred())
+    except Exception as exc:
+        click.echo(f'Failed to fetch starred repositories: {exc}')
+        return
+
+    if os.path.exists(list_file):
+        with open(list_file, 'r') as fh:
+            lists = json.load(fh)
+    else:
+        lists = {}
+
+    openai.api_key = os.environ.get('OPENAI_API_KEY')
+    if not openai.api_key:
+        openai.api_key = getpass('OpenAI API key: ')
+
+    for repo in stars:
+        full_name = repo.full_name
+        # skip if already categorised
+        if any(full_name in repos for repos in lists.values()):
+            continue
+        try:
+            readme = repo.get_readme().decoded_content.decode('utf-8', errors='ignore')
+        except Exception:
+            readme = ''
+        prompt = (
+            'Suggest a one or two word category for this repository based on its README.\n'
+            f'Readme:\n{readme[:4000]}'
+        )
+        try:
+            resp = openai.ChatCompletion.create(
+                model='gpt-3.5-turbo',
+                messages=[{'role': 'user', 'content': prompt}],
+                temperature=0
+            )
+            category = resp.choices[0].message.content.strip().splitlines()[0]
+        except Exception as exc:
+            click.echo(f'OpenAI request failed for {full_name}: {exc}')
+            category = 'Uncategorised'
+        if category not in lists:
+            if create_new:
+                lists[category] = []
+            else:
+                category = 'Uncategorised'
+                lists.setdefault(category, [])
+        lists[category].append(full_name)
+        click.echo(f'{full_name} -> {category}')
+
+    with open(list_file, 'w') as fh:
+        json.dump(lists, fh, indent=2)
+    click.echo(f'Lists saved to {list_file}')
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+PyGithub
+openai
+click
+requests


### PR DESCRIPTION
## Summary
- add CLI app to organise starred repos into lists
- document usage in README
- include requirements file
- support OAuth device flow login instead of PAT

## Testing
- `pip install -r requirements.txt`
- `python organize_stars.py --help`
- `python -m py_compile organize_stars.py`


------
https://chatgpt.com/codex/tasks/task_e_6866d3ac1474832f81b2938225729685